### PR TITLE
[issue-1] Adding the question-mark for querystring seperation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "6"
+  - "5"
+  - "4"

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = class SpeedCurve {
       days   : days || 14
     });
     let options = Object.assign({}, this.options);
-    return request.get(`${API_ENDPOINT}/sites${queries}`, options);
+    return request.get(`${API_ENDPOINT}/sites?${queries}`, options);
   }
 
   /**
@@ -50,7 +50,7 @@ module.exports = class SpeedCurve {
       days    : days || 14
     });
     let options = Object.assign({}, this.options);
-    return request.get(`${API_ENDPOINT}/urls/${urlId}${queries}`, options);
+    return request.get(`${API_ENDPOINT}/urls/${urlId}?${queries}`, options);
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,9 @@
 const test = require('ava');
 const SpeedCurve = require('..');
 const SPEEDCURVE_APIKEY = process.env.SPEEDCURVE_APIKEY;
-
+const SPEEDCURVE_URL_ID = process.env.SPEEDCURVE_URL_ID;
+const SPEEDCURVE_TEST_ID = process.env.SPEEDCURVE_TEST_ID;
+const SPEEDCURVE_DEPLOY_ID = process.enf.SPEEDCURVE_DEPLOY_ID;
 let speedcurve;
 
 test.beforeEach(t => {
@@ -27,7 +29,7 @@ test('getSites(format, days)', async t => {
 });
 
 test('getUrls(urlId, browser, days)', async t => {
-  let urlId = 8601;
+  let urlId = SPEEDCURVE_URL_ID;
   let browser = 'chrome';
   let days = 30;
   let response = await speedcurve.getUrls(urlId, browser, days);
@@ -35,7 +37,7 @@ test('getUrls(urlId, browser, days)', async t => {
 });
 
 test('getTest(testId)', async t => {
-  let testId = '160406_TT_5c9c44ad9fd706d918e5ba47eb03b687';
+  let testId = SPEEDCURVE_TEST_ID;
   let response = await speedcurve.getTest(testId);
   t.truthy(response.body);
 });
@@ -51,7 +53,7 @@ test('getLatestDeploy()', async t => {
 });
 
 test('getDeploy(deployId)', async t => {
-  let deployId = 37732;
+  let deployId = SPEEDCURVE_DEPLOY_ID;
   let response = await speedcurve.getDeploy(deployId);
   t.truthy(response.body);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const SpeedCurve = require('..');
 const SPEEDCURVE_APIKEY = process.env.SPEEDCURVE_APIKEY;
 const SPEEDCURVE_URL_ID = process.env.SPEEDCURVE_URL_ID;
 const SPEEDCURVE_TEST_ID = process.env.SPEEDCURVE_TEST_ID;
-const SPEEDCURVE_DEPLOY_ID = process.enf.SPEEDCURVE_DEPLOY_ID;
+const SPEEDCURVE_DEPLOY_ID = process.env.SPEEDCURVE_DEPLOY_ID;
 let speedcurve;
 
 test.beforeEach(t => {


### PR DESCRIPTION
As of the [Node documentation on querystrings](https://nodejs.org/dist/latest-v6.x/docs/api/querystring.html), the module just creates a String in the format `key=value&key2=value2` without the preceeding questionmark. This PR adds this questionmark. #1 